### PR TITLE
Match build publish to that in config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-publish = "public"
+publish = "docs"
 command = "hugo"
 
 [context.production.environment]


### PR DESCRIPTION
From netlify's docs:

> The publish directory should mirror that of what you’ve set in your site configuration, the default of which is public. 